### PR TITLE
[Untracked] Fix feesPerGas null check & bump up default gas fee multiplier

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,14 +21,14 @@ LOG_LEVEL='info'
 
 # WalletConnect
 # You can find both of the following in your WallectConnect project settings
-# We recommend create a new project 
+# We recommend create a new project
 WC_PROJECT_ID='<project-id>' ## WalletConnect project ID
 
 # Token transfer
 RECIPIENT_ADDRESS='0x...'
 TRANSFER_AMOUNT=0.001
 TOKEN='usdc' ## usdc only for now
-GAS_FEES_MULTIPLIER=1
+GAS_FEES_MULTIPLIER=1.2
 
 # Signing
 SIGNER_ADDRESS='0x...' ## Assumes address exists in SIGNER_ADDRESSES to get private key

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -44,7 +44,7 @@ export const getUserOpHash = async (
     pad(toHex(userOp.verificationGasLimit), { size: 16 }),
     pad(toHex(userOp.callGasLimit), { size: 16 }),
   ]);
-  
+
   const gasFees = concatHex([
     pad(toHex(userOp.maxPriorityFeePerGas), { size: 16 }),
     pad(toHex(userOp.maxFeePerGas), { size: 16 }),
@@ -139,7 +139,7 @@ export const signMessageEIP1193 = async ({
     if (!addresses.map(address => address.toLowerCase()).includes(signer.address.toLowerCase())) {
       logAndExit(`Connected wallet does not contain the signer address: ${signer.address}`);
     }
-  
+
     logger.info(`Requesting signature from ${signer.address}, please check your wallet app and approve the signature request`);
     const signature = await walletClient.signMessage({
       account: signer.address,
@@ -231,10 +231,10 @@ export const estimateUserOp = async ({
     chain: ViemChain[chain],
     transport: http(bundlerRPCUrl),
   });
-  
+
   const feesPerGas = await publicClient.estimateFeesPerGas();
 
-  if (!feesPerGas.maxFeePerGas || !feesPerGas.maxPriorityFeePerGas) {
+  if (feesPerGas.maxFeePerGas === null || feesPerGas.maxFeePerGas === undefined || feesPerGas.maxPriorityFeePerGas === null || feesPerGas.maxPriorityFeePerGas === undefined) {
     logAndExit(`Error estimating fees per gas`)
   }
 
@@ -279,7 +279,7 @@ export const estimateUserOp = async ({
 
   logger.debug(`Original max fee per gas (in Wei): ${feesPerGas.maxFeePerGas}`);
   logger.debug(`Adjusted max fee per gas (in Wei): ${adjustedMaxFeePerGas}`);
-  
+
   logger.debug(`Original max priority fee per gas (in Wei): ${feesPerGas.maxPriorityFeePerGas}`);
   logger.debug(`Adjusted max priority fee per gas (in Wei): ${adjustedMaxPriorityFeePerGas}`);
 
@@ -367,7 +367,7 @@ export const buildAndSignMultisigUserOp = async ({
       ENTRYPOINT_ADDRESS_V07
     );
     const signature = await signMessage({
-      chain, 
+      chain,
       signer,
       message: partialUserOpHash,
       walletConnectProjectId,
@@ -420,7 +420,7 @@ export const buildMultiSigUserOp = async ({
         toHex(v, { size: 1 }),
       ]).slice(2);
     });
-    
+
   const finalUserOp: UserOperation<"v0.7"> = {
     ...multiSigUserOp,
     signature: "0x" + eoaSigs as `0x${string}`

--- a/src/utils/blockchain.ts
+++ b/src/utils/blockchain.ts
@@ -275,7 +275,8 @@ export const estimateUserOp = async ({
   const scaledGasFeesMultiplier = 100 + percentageIncrease;
   const adjustedMaxFeePerGas = feesPerGas.maxFeePerGas! * BigInt(scaledGasFeesMultiplier) / BigInt(100);
   const adjustedMaxPriorityFeePerGasBeforeMin = feesPerGas.maxPriorityFeePerGas! * BigInt(scaledGasFeesMultiplier) / BigInt(100);
-  const adjustedMaxPriorityFeePerGas = maxBigInt(adjustedMaxPriorityFeePerGasBeforeMin, alchemyMaxPriorityFeePerGas)
+  const adjustedAlchemyMaxPriorityFeePerGas = alchemyMaxPriorityFeePerGas * BigInt(scaledGasFeesMultiplier) / BigInt(100);
+  const adjustedMaxPriorityFeePerGas = maxBigInt(adjustedMaxPriorityFeePerGasBeforeMin, adjustedAlchemyMaxPriorityFeePerGas)
 
   logger.debug(`Original max fee per gas (in Wei): ${feesPerGas.maxFeePerGas}`);
   logger.debug(`Adjusted max fee per gas (in Wei): ${adjustedMaxFeePerGas}`);


### PR DESCRIPTION
# Summary
When testing ARB-SEPOLIA there were errors running a token-transfer since there were errors getting the gas fee. After looking closer, one of the values being returned ```maxPriorityFeePerGas``` was  0. On the next line we did a null check, but based on on JavaScript handles falsly values it treated 0 as false 🙃 

So I updated the comparison to explicitly check for null or undefined. I also adjusted the calculations we did with ```adjustedMaxPriorityFeePerGas``` so we'd also scale up the value we got from alchemy. Without scaling this up the gas was too low to get accepted, kept getting ```replacement underpriced``` responses.

Also bumped up default gas fee to 1.2 multiplier. If at 1 most of the time there are problems sending out a transaction.

## Detail

## Testing

## Documentation

---

**Requested Reviewers:** @mention
